### PR TITLE
Adds pritunl example

### DIFF
--- a/compiled/global/README.md
+++ b/compiled/global/README.md
@@ -6,5 +6,6 @@
 |[global](../global/docs/README.md)|
 |[mysql](../mysql/docs/README.md)|
 |[postgres-proxy](../postgres-proxy/docs/README.md)|
+|[pritunl](../pritunl/docs/README.md)|
 |[sock-shop](../sock-shop/docs/README.md)|
 |[tutorial](../tutorial/docs/README.md)|

--- a/compiled/pritunl/docs/README.md
+++ b/compiled/pritunl/docs/README.md
@@ -1,0 +1,16 @@
+# pritunl 
+
+|||
+| --- | --- |
+| **Target** | pritunl |
+| **Project**     | `not defined`|
+| **Cluster**     |  'Not defined'  |
+| **Namespace**   | `pritunl` |
+
+## Components
+| Inventory definition | Documentation |
+| --- | --- |
+|[pritunl.yml](../../inventory/classes/components/pritunl.yml)| [pritunl](pritunl-readme.md)|
+|[pritunl-mongo.yml](../../inventory/classes/components/pritunl-mongo.yml)| [pritunl-mongo](pritunl-mongo-readme.md)|
+
+## Deployments

--- a/compiled/pritunl/docs/pritunl-mongo-readme.md
+++ b/compiled/pritunl/docs/pritunl-mongo-readme.md
@@ -1,0 +1,9 @@
+# Documentation for pritunl-mongo on pritunl
+
+|||
+| --- | ---- |
+| **Component name** | pritunl-mongo |
+| **Application** | Not Defined |
+| **Replicas** | 1 |
+| **Image** | mongo |
+

--- a/compiled/pritunl/docs/pritunl-readme.md
+++ b/compiled/pritunl/docs/pritunl-readme.md
@@ -1,0 +1,12 @@
+# Documentation for pritunl on pritunl
+
+|||
+| --- | ---- |
+| **Component name** | pritunl |
+| **Application** | Not Defined |
+| **Replicas** | 1 |
+| **Image** | alledm/pritunl |
+
+| ENV | VALUE |
+| --- | -----  |
+|MONGO_HOST | pritunl-mongo|

--- a/compiled/pritunl/docs/pritunl-readme.md
+++ b/compiled/pritunl/docs/pritunl-readme.md
@@ -7,6 +7,3 @@
 | **Replicas** | 1 |
 | **Image** | alledm/pritunl |
 
-| ENV | VALUE |
-| --- | -----  |
-|MONGO_HOST | pritunl-mongo|

--- a/compiled/pritunl/manifests/pritunl-bundle.yml
+++ b/compiled/pritunl/manifests/pritunl-bundle.yml
@@ -23,10 +23,7 @@ spec:
         app: pritunl
     spec:
       containers:
-        - env:
-            - name: MONGO_HOST
-              value: pritunl-mongo
-          image: alledm/pritunl
+        - image: alledm/pritunl
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 3
@@ -87,7 +84,7 @@ spec:
       targetPort: http
     - name: vpn
       port: 1194
-      protocol: TCP
+      protocol: UDP
       targetPort: vpn
     - name: webui
       port: 443

--- a/compiled/pritunl/manifests/pritunl-bundle.yml
+++ b/compiled/pritunl/manifests/pritunl-bundle.yml
@@ -1,0 +1,99 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    manifests.kapicorp.com/generated: 'true'
+  labels:
+    app: pritunl
+  name: pritunl
+  namespace: pritunl
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: pritunl
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: pritunl
+    spec:
+      containers:
+        - env:
+            - name: MONGO_HOST
+              value: pritunl-mongo
+          image: alledm/pritunl
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /
+              port: webui
+              scheme: HTTPS
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 3
+          name: pritunl
+          ports:
+            - containerPort: 80
+              name: http
+              protocol: TCP
+            - containerPort: 1194
+              name: vpn
+              protocol: TCP
+            - containerPort: 443
+              name: webui
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /
+              port: webui
+              scheme: HTTPS
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 3
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - mountPath: /etc/pritunl.conf
+              name: config
+              readOnly: true
+              subPath: pritunl.conf
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - configMap:
+            defaultMode: 420
+            name: pritunl
+          name: config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: pritunl
+  name: pritunl
+  namespace: pritunl
+spec:
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: http
+    - name: vpn
+      port: 1194
+      protocol: TCP
+      targetPort: vpn
+    - name: webui
+      port: 443
+      protocol: TCP
+      targetPort: webui
+  selector:
+    app: pritunl
+  sessionAffinity: None
+  type: LoadBalancer

--- a/compiled/pritunl/manifests/pritunl-config.yml
+++ b/compiled/pritunl/manifests/pritunl-config.yml
@@ -1,0 +1,12 @@
+apiVersion: v1
+data:
+  pritunl.conf: "{\n  \"debug\": false,\n  \"bind_addr\": \"0.0.0.0\",\n  \"port\"\
+    : 443,\n  \"log_path\": \"/var/log/pritunl.log\",\n  \"temp_path\": \"/tmp/pritunl_%r\"\
+    ,\n  \"local_address_interface\": \"auto\",\n  \"mongodb_uri\": \"mongodb://pritunl-mongo:27017/pritunl\"\
+    \n}"
+kind: ConfigMap
+metadata:
+  labels:
+    name: pritunl
+  name: pritunl
+  namespace: pritunl

--- a/compiled/pritunl/manifests/pritunl-mongo-bundle.yml
+++ b/compiled/pritunl/manifests/pritunl-mongo-bundle.yml
@@ -1,0 +1,89 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  annotations:
+    manifests.kapicorp.com/generated: 'true'
+  labels:
+    app: pritunl-mongo
+  name: pritunl-mongo
+  namespace: pritunl
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: pritunl-mongo
+  serviceName: pritunl-mongo
+  template:
+    metadata:
+      labels:
+        app: pritunl-mongo
+    spec:
+      containers:
+        - image: mongo
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            failureThreshold: 3
+            periodSeconds: 10
+            successThreshold: 1
+            tcpSocket:
+              port: mongo
+            timeoutSeconds: 3
+          name: pritunl-mongo
+          ports:
+            - containerPort: 27017
+              name: mongo
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: 3
+            periodSeconds: 10
+            successThreshold: 1
+            tcpSocket:
+              port: mongo
+            timeoutSeconds: 3
+          securityContext:
+            capabilities:
+              add:
+                - CHOWN
+                - SETGID
+                - SETUID
+              drop:
+                - all
+          volumeMounts:
+            - mountPath: /bitnami/mongodb
+              name: datadir
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+  updateStrategy:
+    rollingUpdate:
+      partition: 0
+    type: RollingUpdate
+  volumeClaimTemplates:
+    - metadata:
+        labels:
+          name: datadir
+        name: datadir
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 10Gi
+        storageClassName: standard
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: pritunl-mongo
+  name: pritunl-mongo
+  namespace: pritunl
+spec:
+  ports:
+    - name: mongo
+      port: 27017
+      protocol: TCP
+      targetPort: mongo
+  selector:
+    app: pritunl-mongo
+  sessionAffinity: None
+  type: ClusterIP

--- a/components/generators/manifests/schemas.libsonnet
+++ b/components/generators/manifests/schemas.libsonnet
@@ -43,6 +43,7 @@
         properties: {
           enabled: { type: 'boolean' },
           path: { type: 'string' },
+          scheme: { type: 'string', enum: ['HTTP', 'HTTPS'] },
           port: {
             oneOf: [
               { type: 'string' },

--- a/components/generators/manifests/schemas.libsonnet
+++ b/components/generators/manifests/schemas.libsonnet
@@ -205,6 +205,7 @@
           container_port: { type: 'integer' },
           node_port: { type: 'integer' },
           service_port: { type: 'integer' },
+          protocol: { type: 'string', enum: ['UDP', 'TCP']}
         },
         additionalProperties: false,
       },

--- a/inventory/classes/common.yml
+++ b/inventory/classes/common.yml
@@ -3,3 +3,4 @@ classes:
 
 parameters:
   namespace: ${target_name}
+  target_name: ${_reclass_:name:short}

--- a/inventory/classes/components/pritunl/pritunl-mongo.yml
+++ b/inventory/classes/components/pritunl/pritunl-mongo.yml
@@ -1,0 +1,34 @@
+parameters:
+  components:
+    pritunl-mongo:
+      type: statefulset
+      image: mongo
+      service:
+        type: ClusterIP
+      security_context:
+        capabilities:
+          drop:
+            - all
+          add:
+            - CHOWN
+            - SETGID
+            - SETUID
+      ports:
+        mongo:
+          service_port: 27017
+      healthcheck:
+        type: tcp
+        port: mongo
+        probes: ['readiness', 'liveness']
+        timeout_seconds: 3
+      volume_mounts:
+        datadir:
+          mountPath: /bitnami/mongodb
+      volume_claims:
+        datadir:
+          spec:
+            accessModes: ["ReadWriteOnce"]
+            storageClassName: "standard"
+            resources:
+              requests: 
+                storage: 10Gi

--- a/inventory/classes/components/pritunl/pritunl.yml
+++ b/inventory/classes/components/pritunl/pritunl.yml
@@ -3,13 +3,12 @@ parameters:
     pritunl:
       image: alledm/pritunl
       replicas: 1
-      env:
-        MONGO_HOST: pritunl-mongo
       ports:
         http:
           service_port: 80
         vpn:
           service_port: 1194
+          protocol: UDP
         webui:
           service_port: 443
       healthcheck:

--- a/inventory/classes/components/pritunl/pritunl.yml
+++ b/inventory/classes/components/pritunl/pritunl.yml
@@ -1,0 +1,41 @@
+parameters:
+  components:
+    pritunl:
+      image: alledm/pritunl
+      replicas: 1
+      env:
+        MONGO_HOST: pritunl-mongo
+      ports:
+        http:
+          service_port: 80
+        vpn:
+          service_port: 1194
+        webui:
+          service_port: 443
+      healthcheck:
+        type: http
+        scheme: HTTPS
+        path: /
+        port: webui
+        probes: ['readiness', 'liveness']
+        timeout_seconds: 3
+      service:
+        type: LoadBalancer
+      security_context:
+        privileged: true
+      config_maps:
+        config:
+          mount: /etc/pritunl.conf
+          subPath: pritunl.conf
+          data:
+            pritunl.conf: 
+              value: |-
+                {
+                  "debug": false,
+                  "bind_addr": "0.0.0.0",
+                  "port": 443,
+                  "log_path": "/var/log/pritunl.log",
+                  "temp_path": "/tmp/pritunl_%r",
+                  "local_address_interface": "auto",
+                  "mongodb_uri": "mongodb://pritunl-mongo:27017/pritunl"
+                }

--- a/inventory/targets/examples/pritunl.yml
+++ b/inventory/targets/examples/pritunl.yml
@@ -1,0 +1,4 @@
+classes:
+  - common
+  - components.pritunl.pritunl
+  - components.pritunl.pritunl-mongo

--- a/lib/kap.libsonnet
+++ b/lib/kap.libsonnet
@@ -118,8 +118,8 @@ kapitan + kube + {
       {
         port_info:: ports[port_name],
         name: port_name,
-        port: self.port_info.service_port,
-        protocol: 'TCP',
+        port: utils.objectGet(self.port_info, 'service_port'),
+        protocol: utils.objectGet(self.port_info, 'protocol', 'TCP'),
         nodePort: utils.objectGet(self.port_info, 'node_port'),
         targetPort: port_name,
       }


### PR DESCRIPTION
Adds pritunl (https://pritunl.com/) example.

Setup taken from various sites, mainly https://github.com/articulate/helmcharts/tree/master/stable/pritunl

Image re-adapted from https://github.com/andrey0001/pritunl and now moved to https://github.com/ademariag/pritunl

TODO: Mongo setup needs hardening