### PR TITLE
Fix issue #27: files owned by root

### DIFF
--- a/kapitan
+++ b/kapitan
@@ -10,7 +10,7 @@ if hash kapitan 2> /dev/null
 then
   KAPITAN_BINARY=kapitan
 else
-  KAPITAN_BINARY="docker run --rm -i --network host -w /src \
+  KAPITAN_BINARY="docker run --rm -i -u $UID --network host -w /src \
    -v $PWD:/src:delegated \
    $KAPITAN_IMAGE kapitan"
 fi


### PR DESCRIPTION
Fix issue #27 by adding the `-u $UID` docker option there. (As documented in https://kapitan.dev/#quickstart) 