### PR TITLE
multiple healthcheck types

### DIFF
--- a/compiled/dev-sockshop/manifests/catalogue-bundle.yml
+++ b/compiled/dev-sockshop/manifests/catalogue-bundle.yml
@@ -41,7 +41,7 @@ spec:
             initialDelaySeconds: 0
             periodSeconds: 10
             successThreshold: 1
-            timeoutSeconds: 3
+            timeoutSeconds: 5
           name: catalogue
           ports:
             - containerPort: 80

--- a/compiled/dev-sockshop/manifests/frontend-bundle.yml
+++ b/compiled/dev-sockshop/manifests/frontend-bundle.yml
@@ -40,7 +40,7 @@ spec:
             initialDelaySeconds: 0
             periodSeconds: 10
             successThreshold: 1
-            timeoutSeconds: 3
+            timeoutSeconds: 5
           name: frontend
           ports:
             - containerPort: 8079

--- a/compiled/dev-sockshop/manifests/orders-bundle.yml
+++ b/compiled/dev-sockshop/manifests/orders-bundle.yml
@@ -40,10 +40,10 @@ spec:
               path: /health
               port: http
               scheme: HTTP
-            initialDelaySeconds: 120
+            initialDelaySeconds: 0
             periodSeconds: 10
             successThreshold: 1
-            timeoutSeconds: 3
+            timeoutSeconds: 5
           name: orders
           ports:
             - containerPort: 80

--- a/compiled/dev-sockshop/manifests/payment-bundle.yml
+++ b/compiled/dev-sockshop/manifests/payment-bundle.yml
@@ -37,7 +37,7 @@ spec:
             initialDelaySeconds: 0
             periodSeconds: 10
             successThreshold: 1
-            timeoutSeconds: 3
+            timeoutSeconds: 5
           name: payment
           ports:
             - containerPort: 80

--- a/compiled/dev-sockshop/manifests/queue-master-bundle.yml
+++ b/compiled/dev-sockshop/manifests/queue-master-bundle.yml
@@ -43,7 +43,7 @@ spec:
             initialDelaySeconds: 0
             periodSeconds: 10
             successThreshold: 1
-            timeoutSeconds: 3
+            timeoutSeconds: 5
           name: queue-master
           ports:
             - containerPort: 80

--- a/compiled/dev-sockshop/manifests/shipping-bundle.yml
+++ b/compiled/dev-sockshop/manifests/shipping-bundle.yml
@@ -37,10 +37,10 @@ spec:
               path: /health
               port: http
               scheme: HTTP
-            initialDelaySeconds: 120
+            initialDelaySeconds: 0
             periodSeconds: 10
             successThreshold: 1
-            timeoutSeconds: 3
+            timeoutSeconds: 5
           name: shipping
           ports:
             - containerPort: 80

--- a/compiled/dev-sockshop/manifests/user-bundle.yml
+++ b/compiled/dev-sockshop/manifests/user-bundle.yml
@@ -37,7 +37,7 @@ spec:
             initialDelaySeconds: 0
             periodSeconds: 10
             successThreshold: 1
-            timeoutSeconds: 3
+            timeoutSeconds: 5
           name: user
           ports:
             - containerPort: 80

--- a/compiled/echo-server/manifests/echo-server-bundle.yml
+++ b/compiled/echo-server/manifests/echo-server-bundle.yml
@@ -25,6 +25,16 @@ spec:
       containers:
         - image: jmalloc/echo-server
           imagePullPolicy: IfNotPresent
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /_health
+              port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 3
           name: echo-server
           ports:
             - containerPort: 8080
@@ -36,13 +46,13 @@ spec:
           readinessProbe:
             failureThreshold: 3
             httpGet:
-              path: /_health
+              path: /_ready
               port: http
               scheme: HTTP
             initialDelaySeconds: 0
             periodSeconds: 10
             successThreshold: 1
-            timeoutSeconds: 3
+            timeoutSeconds: 5
           volumeMounts:
             - mountPath: /opt/echo-service
               name: config

--- a/compiled/prod-sockshop/manifests/catalogue-bundle.yml
+++ b/compiled/prod-sockshop/manifests/catalogue-bundle.yml
@@ -41,7 +41,7 @@ spec:
             initialDelaySeconds: 0
             periodSeconds: 10
             successThreshold: 1
-            timeoutSeconds: 3
+            timeoutSeconds: 5
           name: catalogue
           ports:
             - containerPort: 80

--- a/compiled/prod-sockshop/manifests/frontend-bundle.yml
+++ b/compiled/prod-sockshop/manifests/frontend-bundle.yml
@@ -40,7 +40,7 @@ spec:
             initialDelaySeconds: 0
             periodSeconds: 10
             successThreshold: 1
-            timeoutSeconds: 3
+            timeoutSeconds: 5
           name: frontend
           ports:
             - containerPort: 8079

--- a/compiled/prod-sockshop/manifests/orders-bundle.yml
+++ b/compiled/prod-sockshop/manifests/orders-bundle.yml
@@ -40,10 +40,10 @@ spec:
               path: /health
               port: http
               scheme: HTTP
-            initialDelaySeconds: 120
+            initialDelaySeconds: 0
             periodSeconds: 10
             successThreshold: 1
-            timeoutSeconds: 3
+            timeoutSeconds: 5
           name: orders
           ports:
             - containerPort: 80

--- a/compiled/prod-sockshop/manifests/payment-bundle.yml
+++ b/compiled/prod-sockshop/manifests/payment-bundle.yml
@@ -37,7 +37,7 @@ spec:
             initialDelaySeconds: 0
             periodSeconds: 10
             successThreshold: 1
-            timeoutSeconds: 3
+            timeoutSeconds: 5
           name: payment
           ports:
             - containerPort: 80

--- a/compiled/prod-sockshop/manifests/queue-master-bundle.yml
+++ b/compiled/prod-sockshop/manifests/queue-master-bundle.yml
@@ -43,7 +43,7 @@ spec:
             initialDelaySeconds: 0
             periodSeconds: 10
             successThreshold: 1
-            timeoutSeconds: 3
+            timeoutSeconds: 5
           name: queue-master
           ports:
             - containerPort: 80

--- a/compiled/prod-sockshop/manifests/shipping-bundle.yml
+++ b/compiled/prod-sockshop/manifests/shipping-bundle.yml
@@ -37,10 +37,10 @@ spec:
               path: /health
               port: http
               scheme: HTTP
-            initialDelaySeconds: 120
+            initialDelaySeconds: 0
             periodSeconds: 10
             successThreshold: 1
-            timeoutSeconds: 3
+            timeoutSeconds: 5
           name: shipping
           ports:
             - containerPort: 80

--- a/compiled/prod-sockshop/manifests/user-bundle.yml
+++ b/compiled/prod-sockshop/manifests/user-bundle.yml
@@ -37,7 +37,7 @@ spec:
             initialDelaySeconds: 0
             periodSeconds: 10
             successThreshold: 1
-            timeoutSeconds: 3
+            timeoutSeconds: 5
           name: user
           ports:
             - containerPort: 80

--- a/compiled/sock-shop/manifests/catalogue-bundle.yml
+++ b/compiled/sock-shop/manifests/catalogue-bundle.yml
@@ -41,7 +41,7 @@ spec:
             initialDelaySeconds: 0
             periodSeconds: 10
             successThreshold: 1
-            timeoutSeconds: 3
+            timeoutSeconds: 5
           name: catalogue
           ports:
             - containerPort: 80

--- a/compiled/sock-shop/manifests/frontend-bundle.yml
+++ b/compiled/sock-shop/manifests/frontend-bundle.yml
@@ -40,7 +40,7 @@ spec:
             initialDelaySeconds: 0
             periodSeconds: 10
             successThreshold: 1
-            timeoutSeconds: 3
+            timeoutSeconds: 5
           name: frontend
           ports:
             - containerPort: 8079

--- a/compiled/sock-shop/manifests/orders-bundle.yml
+++ b/compiled/sock-shop/manifests/orders-bundle.yml
@@ -40,10 +40,10 @@ spec:
               path: /health
               port: http
               scheme: HTTP
-            initialDelaySeconds: 120
+            initialDelaySeconds: 0
             periodSeconds: 10
             successThreshold: 1
-            timeoutSeconds: 3
+            timeoutSeconds: 5
           name: orders
           ports:
             - containerPort: 80

--- a/compiled/sock-shop/manifests/payment-bundle.yml
+++ b/compiled/sock-shop/manifests/payment-bundle.yml
@@ -37,7 +37,7 @@ spec:
             initialDelaySeconds: 0
             periodSeconds: 10
             successThreshold: 1
-            timeoutSeconds: 3
+            timeoutSeconds: 5
           name: payment
           ports:
             - containerPort: 80

--- a/compiled/sock-shop/manifests/queue-master-bundle.yml
+++ b/compiled/sock-shop/manifests/queue-master-bundle.yml
@@ -43,7 +43,7 @@ spec:
             initialDelaySeconds: 0
             periodSeconds: 10
             successThreshold: 1
-            timeoutSeconds: 3
+            timeoutSeconds: 5
           name: queue-master
           ports:
             - containerPort: 80

--- a/compiled/sock-shop/manifests/shipping-bundle.yml
+++ b/compiled/sock-shop/manifests/shipping-bundle.yml
@@ -37,10 +37,10 @@ spec:
               path: /health
               port: http
               scheme: HTTP
-            initialDelaySeconds: 120
+            initialDelaySeconds: 0
             periodSeconds: 10
             successThreshold: 1
-            timeoutSeconds: 3
+            timeoutSeconds: 5
           name: shipping
           ports:
             - containerPort: 80

--- a/compiled/sock-shop/manifests/user-bundle.yml
+++ b/compiled/sock-shop/manifests/user-bundle.yml
@@ -37,7 +37,7 @@ spec:
             initialDelaySeconds: 0
             periodSeconds: 10
             successThreshold: 1
-            timeoutSeconds: 3
+            timeoutSeconds: 5
           name: user
           ports:
             - containerPort: 80

--- a/compiled/tutorial/manifests/echo-server-bundle.yml
+++ b/compiled/tutorial/manifests/echo-server-bundle.yml
@@ -28,6 +28,16 @@ spec:
               value: microservices
           image: jmalloc/echo-server
           imagePullPolicy: IfNotPresent
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /_health
+              port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 3
           name: echo-server
           ports:
             - containerPort: 8080
@@ -39,13 +49,13 @@ spec:
           readinessProbe:
             failureThreshold: 3
             httpGet:
-              path: /_health
+              path: /_ready
               port: http
               scheme: HTTP
             initialDelaySeconds: 0
             periodSeconds: 10
             successThreshold: 1
-            timeoutSeconds: 3
+            timeoutSeconds: 5
           volumeMounts:
             - mountPath: /opt/echo-service
               name: config

--- a/components/generators/manifests/resources.libsonnet
+++ b/components/generators/manifests/resources.libsonnet
@@ -33,9 +33,9 @@ local p = kap.parameters;
     .WithCommand(utils.objectGet(service_component, 'command'))
     .WithEnvs(utils.objectGet(service_component, 'env', {}))
     .WithImage(utils.objectGet(service_component, 'image'))
-    .WithLivenessProbe(utils.objectGet(service_component, 'healthcheck', { probes: [] }), service_component.healthcheck)
+    .WithLivenessProbe(utils.objectGet(service_component, 'healthcheck', {}), service_component.healthcheck)
     .WithPorts(utils.objectGet(service_component, 'ports', {}))
-    .WithReadinessProbe(utils.objectGet(service_component, 'healthcheck', { probes: [] }), service_component.healthcheck)
+    .WithReadinessProbe(utils.objectGet(service_component, 'healthcheck', {}), service_component.healthcheck)
     .WithRunAsUser(utils.objectGet(service_component.security, 'user_id'), 'security' in service_component)
     .WithSecurityContext(utils.objectGet(service_component, 'security_context', {}))
     .WithAllowPrivilegeEscalation(utils.objectGet(service_component.security, 'allow_privilege_escalation'), 'security' in service_component)
@@ -137,12 +137,12 @@ local p = kap.parameters;
         config: utils.objectGet(service_component, 'secrets', {}),
         global_annotations: utils.objectGet(global_annotations, 'secrets', {}),
         generating_class: kap.K8sSecret
-      }, 
+      },
       migration_secrets: {
         config: utils.deepMerge(config_helpers.secrets.config, utils.objectGet(service_component.migration, 'secrets', {})),
         global_annotations: utils.objectGet(global_annotations, 'secrets', {}),
         generating_class: kap.K8sSecret
-      }, 
+      },
       config_maps: {
         config: utils.objectGet(service_component, 'config_maps', {}),
         global_annotations: utils.objectGet(global_annotations, 'config_maps', {}),
@@ -165,9 +165,9 @@ local p = kap.parameters;
       [name]: MergeConfig(name, helper)
       for name in std.objectFields(helper.config)
     };
- 
-    local objects = { 
-      [name]: CreateConfigDefinition(config_helpers[name]) 
+
+    local objects = {
+      [name]: CreateConfigDefinition(config_helpers[name])
         for name in std.objectFields(config_helpers)
     };
 

--- a/components/generators/manifests/schema.json
+++ b/components/generators/manifests/schema.json
@@ -1,423 +1,651 @@
 {
-  additionalProperties: false,
-  definitions: {
-    config: {
-      properties: {
-        data: {
-          additionalProperties: {
-            additionalProperties: false,
-            properties: {
-              b64_encode: {
-                type: 'boolean',
+  "additionalProperties": false,
+  "definitions": {
+    "config": {
+      "properties": {
+        "data": {
+          "additionalProperties": {
+            "additionalProperties": false,
+            "properties": {
+              "b64_encode": {
+                "type": "boolean"
               },
-              template: {
-                type: 'string',
+              "template": {
+                "type": "string"
               },
-              value: {
-                type: 'string',
+              "value": {
+                "type": "string"
               },
-              values: {
-                type: 'object',
-              },
+              "values": {
+                "type": "object"
+              }
             },
-            type: 'object',
+            "type": "object"
           },
-          type: 'object',
+          "type": "object"
         },
-        items: {
-          items: {
-            type: 'string',
+        "items": {
+          "items": {
+            "type": "string"
           },
-          type: 'array',
+          "type": "array"
         },
-        mount: {
-          type: 'string',
-        },
+        "mount": {
+          "type": "string"
+        }
       },
-      required: [
-        'data',
+      "required": [
+        "data"
       ],
-      type: 'object',
+      "type": "object"
     },
-    kube_env: {
-      items: {
-        additionalProperties: false,
-        properties: {
-          name: {
-            type: 'string',
-          },
-          value: {
-            type: 'string',
-          },
-          valueFrom: {
-            anyOf: [
-              {
-                additionalProperties: false,
-                properties: {
-                  secretKeyRef: {
-                    additionalProperties: false,
-                    properties: {
-                      key: {
-                        type: 'string',
-                      },
-                      optional: {
-                        type: 'boolean',
-                      },
-                    },
-                    required: [
-                      'key',
-                    ],
-                    type: 'object',
-                  },
-                },
-                required: [
-                  'secretKeyRef',
-                ],
-                type: 'object',
+    "globals": {
+      "properties": {
+        "annotations": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "additionalValues": {
+                "type": "string"
               },
-              {
-                additionalProperties: false,
-                properties: {
-                  fieldRef: {
-                    additionalProperties: false,
-                    properties: {
-                      fieldPath: {
-                        type: 'string',
-                      },
-                    },
-                    required: [
-                      'fieldPath',
-                    ],
-                    type: 'object',
-                  },
-                },
-                required: [
-                  'fieldRef',
-                ],
-                type: 'object',
-              },
-            ],
-          },
+              "type": "object"
+            }
+          ]
         },
-        required: [
-          'name',
+        "labels": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "additionalValues": {
+                "type": "string"
+              },
+              "type": "object"
+            }
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "kube_env": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          },
+          "valueFrom": {
+            "anyOf": [
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "secretKeyRef": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "key": {
+                        "type": "string"
+                      },
+                      "optional": {
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "key"
+                    ],
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "secretKeyRef"
+                ],
+                "type": "object"
+              },
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "fieldRef": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "fieldPath": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "fieldPath"
+                    ],
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "fieldRef"
+                ],
+                "type": "object"
+              }
+            ]
+          }
+        },
+        "required": [
+          "name"
         ],
-        type: 'object',
+        "type": "object"
       },
-      type: 'array',
+      "type": "array"
     },
-    port_set: {
-      additionalProperties: false,
-      properties: {
-        container_port: {
-          type: 'integer',
+    "port_set": {
+      "additionalProperties": false,
+      "properties": {
+        "container_port": {
+          "type": "integer"
         },
-        node_port: {
-          type: 'integer',
+        "node_port": {
+          "type": "integer"
         },
-        service_port: {
-          type: 'integer',
+        "protocol": {
+          "enum": [
+            "UDP",
+            "TCP"
+          ],
+          "type": "string"
         },
+        "service_port": {
+          "type": "integer"
+        }
       },
-      type: 'object',
+      "type": "object"
     },
-    secret: {
-      properties: {
-        data: {
-          additionalProperties: {
-            additionalProperties: false,
-            properties: {
-              b64_encode: {
-                type: 'boolean',
-              },
-              template: {
-                type: 'string',
-              },
-              value: {
-                type: 'string',
-              },
-              values: {
-                type: 'object',
-              },
-            },
-            type: 'object',
-          },
-          type: 'object',
-        },
-        items: {
-          items: {
-            type: 'string',
-          },
-          type: 'array',
-        },
-        mount: {
-          type: 'string',
-        },
-      },
-      required: [
-        'data',
-      ],
-      type: 'object',
-    },
-    volume_claim: {
-      properties: {
-        spec: {
-          type: 'object',
-        },
-      },
-      type: 'object',
-    },
-  },
-  description: 'Schema for Kapitan manifest generator',
-  properties: {
-    annotations: {
-      additionalProperties: {
-        type: 'string',
-      },
-      description: 'Annotations to pass to the workload',
-      type: 'object',
-    },
-    application: {
-      description: 'Associates this component to an application.',
-      type: 'string',
-    },
-    args: {
-      description: 'Args to pass to the workload',
-      items: {
-        type: 'string',
-      },
-      type: 'array',
-    },
-    command: {
-      description: 'command to pass to the workload',
-      items: {
-        type: 'string',
-      },
-      type: 'array',
-    },
-    config_maps: {
-      anyOf: [
-        {
-          type: 'null',
-        },
-        {
-          additionalProperties: {
-            '$ref': '#/definitions/config',
-          },
-          type: 'object',
-        },
-      ],
-      description: 'Config maps for the workload',
-    },
-    deployment_progress_deadline_seconds: {
-      anyOf: [
-        {
-          type: 'null',
-        },
-        {
-          type: 'integer',
-        },
-      ],
-    },
-    dns_policy: {
-      enum: [
-        'ClusterFirst',
-      ],
-      type: 'string',
-    },
-    enable_prometheus: {
-      type: 'boolean',
-    },
-    env: {
-      anyOf: [
-        {
-          type: 'null',
-        },
-        {
-          type: 'object',
-        },
-      ],
-    },
-    healthcheck: {
-      additionalProperties: false,
-      properties: {
-        enabled: {
-          type: 'boolean',
-        },
-        path: {
-          type: 'string',
-        },
-        port: {
-          oneOf: [
+    "secret": {
+      "properties": {
+        "annotations": {
+          "anyOf": [
             {
-              type: 'string',
+              "type": "null"
             },
             {
-              type: 'integer',
+              "additionalValues": {
+                "type": "string"
+              },
+              "type": "object"
+            }
+          ]
+        },
+        "data": {
+          "additionalProperties": {
+            "additionalProperties": false,
+            "properties": {
+              "b64_encode": {
+                "type": "boolean"
+              },
+              "template": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              },
+              "values": {
+                "type": "object"
+              }
             },
-          ],
-        },
-        probes: {
-          items: {
-            enum: [
-              'readiness',
-              'liveness',
-            ],
-            type: 'string',
+            "type": "object"
           },
-          type: 'array',
+          "type": "object"
         },
-        timeout_seconds: {
-          type: 'integer',
-        },
-        type: {
-          type: 'string',
-        },
-      },
-      required: [
-        'type',
-        'probes',
-      ],
-      type: 'object',
-    },
-    image: {
-      type: 'string',
-    },
-    labels: {
-      additionalProperties: {
-        type: 'string',
-      },
-      type: 'object',
-    },
-    min_ready_seconds: {
-      type: 'integer',
-    },
-    name: {
-      type: 'string',
-    },
-    pdb_min_available: {
-      type: 'integer',
-    },
-    ports: {
-      additionalProperties: {
-        '$ref': '#/definitions/port_set',
-      },
-      type: 'object',
-    },
-    prefer_pods_in_different_nodes: {
-      type: 'boolean',
-    },
-    prefer_pods_in_different_zones: {
-      type: 'boolean',
-    },
-    prefer_pods_in_node_type: {
-      type: 'string',
-    },
-    replicas: {
-      type: 'integer',
-    },
-    secrets: {
-      anyOf: [
-        {
-          type: 'null',
-        },
-        {
-          additionalProperties: {
-            '$ref': '#/definitions/secret',
+        "items": {
+          "items": {
+            "type": "string"
           },
-          type: 'object',
+          "type": "array"
         },
-      ],
-    },
-    security: {
-      anyOf: [
-        {
-          type: 'null',
-        },
-        {
-          additionalProperties: false,
-          properties: {
-            allow_privilege_escalation: {
-              type: 'boolean',
-            },
-            user_id: {
-              type: 'integer',
-            },
-          },
-          type: 'object',
-        },
-      ],
-    },
-    service: {
-      additionalProperties: false,
-      properties: {
-        annotations: {
-          additionalValues: {
-            type: 'string',
-          },
-          type: 'object',
-        },
-        externalTrafficPolicy: {
-          enum: [
-            'Cluster',
-          ],
-          type: 'string',
-        },
-        grpc: {
-          type: 'object',
-        },
-        type: {
-          enum: [
-            'NodePort',
-            'ClusterIP',
-            'LoadBalancer',
-          ],
-          type: 'string',
-        },
+        "mount": {
+          "type": "string"
+        }
       },
-      type: 'object',
-    },
-    service_account: {
-      type: 'boolean',
-    },
-    type: {
-      enum: [
-        'statefulset',
-        'deployment',
+      "required": [
+        "data"
       ],
-      type: 'string',
+      "type": "object"
     },
-    volume_claims: {
-      additionalProperties: {
-        '$ref': '#/definitions/volume_claim',
+    "volume_claim": {
+      "properties": {
+        "spec": {
+          "type": "object"
+        }
       },
-      type: 'object',
-    },
-    volume_mounts: {
-      additionalProperties: {
-        type: 'object',
-      },
-      type: 'object',
-    },
-    volumes: {
-      additionalProperties: {
-        type: 'object',
-      },
-      type: 'object',
-    },
-    vpa: {
-      enum: [
-        'Off',
-        'Auto',
-      ],
-      type: 'string',
-    },
+      "type": "object"
+    }
   },
-  required: [
-    'name',
-    'image',
-    'type',
+  "description": "Schema for Kapitan manifest generator",
+  "properties": {
+    "annotations": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "description": "Annotations to pass to the workload",
+      "type": "object"
+    },
+    "application": {
+      "description": "Associates this component to an application.",
+      "type": "string"
+    },
+    "args": {
+      "description": "Args to pass to the workload",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "cluster_role": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "object"
+        }
+      ]
+    },
+    "command": {
+      "description": "command to pass to the workload",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "config_maps": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "additionalProperties": {
+            "$ref": "#/definitions/config"
+          },
+          "type": "object"
+        }
+      ],
+      "description": "Config maps for the workload"
+    },
+    "deployment_progress_deadline_seconds": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "integer"
+        }
+      ]
+    },
+    "dns_policy": {
+      "enum": [
+        "ClusterFirst"
+      ],
+      "type": "string"
+    },
+    "enable_prometheus": {
+      "type": "boolean"
+    },
+    "enabled": {
+      "type": "boolean"
+    },
+    "env": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "object"
+        }
+      ]
+    },
+    "globals": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "configmaps": {
+              "additionalProperties": {
+                "$ref": "#/definitions/globals"
+              },
+              "type": "object"
+            },
+            "secrets": {
+              "additionalProperties": {
+                "$ref": "#/definitions/globals"
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        }
+      ]
+    },
+    "healthcheck": {
+      "additionalProperties": false,
+      "properties": {
+        "liveness": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "properties": {
+                "command": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "enabled": {
+                  "type": "boolean"
+                },
+                "failure_threshold": {
+                  "type": "integer"
+                },
+                "initial_delay_seconds": {
+                  "type": "integer"
+                },
+                "path": {
+                  "type": "string"
+                },
+                "period_seconds": {
+                  "type": "integer"
+                },
+                "port": {
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "integer"
+                    }
+                  ]
+                },
+                "scheme": {
+                  "enum": [
+                    "HTTP",
+                    "HTTPS"
+                  ],
+                  "type": "string"
+                },
+                "success_threshold": {
+                  "type": "integer"
+                },
+                "timeout_seconds": {
+                  "type": "integer"
+                },
+                "type": {
+                  "enum": [
+                    "command",
+                    "http",
+                    "tcp"
+                  ],
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          ]
+        },
+        "readiness": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "properties": {
+                "command": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "enabled": {
+                  "type": "boolean"
+                },
+                "failure_threshold": {
+                  "type": "integer"
+                },
+                "initial_delay_seconds": {
+                  "type": "integer"
+                },
+                "path": {
+                  "type": "string"
+                },
+                "period_seconds": {
+                  "type": "integer"
+                },
+                "port": {
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "integer"
+                    }
+                  ]
+                },
+                "scheme": {
+                  "enum": [
+                    "HTTP",
+                    "HTTPS"
+                  ],
+                  "type": "string"
+                },
+                "success_threshold": {
+                  "type": "integer"
+                },
+                "timeout_seconds": {
+                  "type": "integer"
+                },
+                "type": {
+                  "enum": [
+                    "command",
+                    "http",
+                    "tcp"
+                  ],
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "image": {
+      "type": "string"
+    },
+    "labels": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "min_ready_seconds": {
+      "type": "integer"
+    },
+    "name": {
+      "type": "string"
+    },
+    "node_selector_labels": {
+      "type": "object"
+    },
+    "pdb_min_available": {
+      "type": "integer"
+    },
+    "ports": {
+      "additionalProperties": {
+        "$ref": "#/definitions/port_set"
+      },
+      "type": "object"
+    },
+    "prefer_pods_in_different_nodes": {
+      "type": "boolean"
+    },
+    "prefer_pods_in_different_zones": {
+      "type": "boolean"
+    },
+    "prefer_pods_in_node_type": {
+      "type": "string"
+    },
+    "replicas": {
+      "type": "integer"
+    },
+    "secrets": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "additionalProperties": {
+            "$ref": "#/definitions/secret"
+          },
+          "type": "object"
+        }
+      ]
+    },
+    "security": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "allow_privilege_escalation": {
+              "type": "boolean"
+            },
+            "user_id": {
+              "type": "integer"
+            }
+          },
+          "type": "object"
+        }
+      ]
+    },
+    "security_context": {
+      "type": "object"
+    },
+    "service": {
+      "additionalProperties": false,
+      "properties": {
+        "annotations": {
+          "additionalValues": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "externalTrafficPolicy": {
+          "enum": [
+            "Cluster"
+          ],
+          "type": "string"
+        },
+        "grpc": {
+          "type": "object"
+        },
+        "type": {
+          "enum": [
+            "NodePort",
+            "ClusterIP",
+            "LoadBalancer"
+          ],
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "service_account": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "annotations": {
+              "anyOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "additionalValues": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                }
+              ]
+            },
+            "create": {
+              "type": "boolean"
+            },
+            "enabled": {
+              "type": "boolean"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      ]
+    },
+    "type": {
+      "enum": [
+        "statefulset",
+        "deployment"
+      ],
+      "type": "string"
+    },
+    "update_strategy": {
+      "type": "object"
+    },
+    "volume_claims": {
+      "additionalProperties": {
+        "$ref": "#/definitions/volume_claim"
+      },
+      "type": "object"
+    },
+    "volume_mounts": {
+      "additionalProperties": {
+        "type": "object"
+      },
+      "type": "object"
+    },
+    "volumes": {
+      "additionalProperties": {
+        "type": "object"
+      },
+      "type": "object"
+    },
+    "vpa": {
+      "enum": [
+        "Off",
+        "Auto"
+      ],
+      "type": "string"
+    },
+    "webhooks": {
+      "items": {
+        "type": "object"
+      },
+      "type": "array"
+    }
+  },
+  "required": [
+    "name",
+    "image",
+    "type"
   ],
-  title: 'manifest generator',
-  type: 'object',
+  "title": "manifest generator",
+  "type": "object"
 }

--- a/components/generators/manifests/schemas.libsonnet
+++ b/components/generators/manifests/schemas.libsonnet
@@ -43,32 +43,56 @@
       healthcheck: {
         type: 'object',
         properties: {
-          enabled: { type: 'boolean' },
-          path: { type: 'string' },
-          scheme: { type: 'string', enum: ['HTTP', 'HTTPS'] },
-          port: {
-            oneOf: [
-              { type: 'string' },
-              { type: 'integer' },
-            ],
+          readiness: { anyOf: [{ type: 'null' }, { 
+            type: 'object',
+            properties: {
+              type: { type: 'string', enum: ['command', 'http', 'tcp'] },
+              timeout_seconds: { type: 'integer' },
+              initial_delay_seconds: { type: 'integer' },
+              failure_threshold: { type: 'integer' },
+              success_threshold: { type: 'integer' },
+              period_seconds: { type: 'integer' },
+              enabled: { type: 'boolean' },
+              path: { type: 'string' },
+              scheme: { type: 'string', enum: ['HTTP', 'HTTPS'] },
+              port: {
+                oneOf: [
+                  { type: 'string' },
+                  { type: 'integer' },
+                ],
+              },
+              command: {
+                type: 'array',
+                items: {type: 'string'},
+              },              
+            }}] 
           },
-          command: {
-            type: 'array',
-            items: {type: 'string'},
-          },
-          probes: {
-            type: 'array',
-            items: { type: 'string', enum: ['readiness', 'liveness'] },
-          },
-          type: { type: 'string', enum: ['command', 'http', 'tcp'] },
-          timeout_seconds: { type: 'integer' },
-          initial_delay_seconds: { type: 'integer' },
-          failure_threshold: { type: 'integer' },
-          success_threshold: { type: 'integer' },
-          period_seconds: { type: 'integer' },
+          liveness: { anyOf: [{ type: 'null' }, { 
+            type: 'object',
+            properties: {
+              type: { type: 'string', enum: ['command', 'http', 'tcp'] },
+              timeout_seconds: { type: 'integer' },
+              initial_delay_seconds: { type: 'integer' },
+              failure_threshold: { type: 'integer' },
+              success_threshold: { type: 'integer' },
+              period_seconds: { type: 'integer' },
+              enabled: { type: 'boolean' },
+              path: { type: 'string' },
+              scheme: { type: 'string', enum: ['HTTP', 'HTTPS'] },
+              port: {
+                oneOf: [
+                  { type: 'string' },
+                  { type: 'integer' },
+                ],
+              },
+              command: {
+                type: 'array',
+                items: {type: 'string'},
+              },              
+            }}]
+          }
         },
         additionalProperties: false,
-        required: ['type', 'probes'],
       },
       image: { type: 'string' },
       labels: { type: 'object', additionalProperties: { type: 'string' } },

--- a/inventory/classes/components/echo-server.yml
+++ b/inventory/classes/components/echo-server.yml
@@ -6,11 +6,16 @@ parameters:
       service:
         type: LoadBalancer
       healthcheck:
-        type: http
-        port: http
-        probes: ['readiness']
-        path: /_health
-        timeout_seconds: 3
+        liveness:
+          type: http
+          port: http
+          path: /_health
+          timeout_seconds: 3
+        readiness:
+          type: http
+          port: http
+          path: /_ready
+          timeout_seconds: 5
       ports:
         http:
           service_port: 80
@@ -33,7 +38,7 @@ parameters:
             - echo-service.conf
           data:
             echo-service.conf:
-              template: 'components/echo-server/echo-server.conf.j2'
+              template: "components/echo-server/echo-server.conf.j2"
               values:
                 example: true
             simple_config:

--- a/inventory/classes/components/gke-pvm-killer.yml
+++ b/inventory/classes/components/gke-pvm-killer.yml
@@ -3,7 +3,7 @@ parameters:
     gke-pvm-killer:
       ref: plain:targets/${target_name}/gke-pvm-killer-service-account
       secret: ?{plain:targets/${target_name}/gke-pvm-killer-service-account||randomstr}
-      name: gke-pvm-killer@${google_project}.iam.gserviceaccount.com 
+      name: gke-pvm-killer@${google_project}.iam.gserviceaccount.com
 
   scripts:
     - templates/scripts/generate_sa_secrets.sh
@@ -17,11 +17,16 @@ parameters:
         prom-metrics:
           service_port: 9001
       healthcheck:
-        type: http
-        probes: ["liveness", "readiness"]
-        path: /liveness
-        port: liveness
-        timeout_seconds: 3
+        readiness:
+          type: http
+          port: liveness
+          path: /liveness
+          timeout_seconds: 3
+        liveness:
+          type: http
+          port: liveness
+          path: /liveness
+          timeout_seconds: 3
       env:
         DRAIN_TIMEOUT: "300"
         INTERVAL: "600"

--- a/inventory/classes/components/logstash.yml
+++ b/inventory/classes/components/logstash.yml
@@ -9,21 +9,21 @@ parameters:
         http:
           container_port: 9600
       healthcheck:
-        type: http
-        port: 9600
-        probes: ['readiness']
-        path: /
-        timeout_seconds: 3
+        readiness:
+          type: http
+          port: 9600
+          path: /
+          timeout_seconds: 3
       image: eu.gcr.io/antha-images/logstash:7.5.1
       config_maps:
         config:
           mount: /usr/share/logstash/config/
           data:
             logstash.yml:
-              template: components/logstash/templates/logstash.yml.j2 
+              template: components/logstash/templates/logstash.yml.j2
               values: {}
             pipelines.yml:
-              template: components/logstash/templates/pipelines.yml.j2 
+              template: components/logstash/templates/pipelines.yml.j2
               values: {}
         pipelines:
           mount: /usr/share/logstash/pipeline/

--- a/inventory/classes/components/postgres-proxy.yml
+++ b/inventory/classes/components/postgres-proxy.yml
@@ -6,7 +6,7 @@ parameters:
     postgres-proxy:
       ref: plain:targets/${target_name}/postgres-proxy-service-account
       secret: ?{plain:targets/${target_name}/postgres-proxy-service-account||randomstr}
-      name: postgres-proxy@${google_project}.iam.gserviceaccount.com 
+      name: postgres-proxy@${google_project}.iam.gserviceaccount.com
 
   scripts:
     - templates/scripts/generate_sa_secrets.sh
@@ -23,10 +23,10 @@ parameters:
         GOOGLE_APPLICATION_CREDENTIALS: /opt/secrets/service_account_file
       replicas: 3
       healthcheck:
-        type: tcp
-        port: postgresql
-        probes: ['liveness']
-        timeout_seconds: 1
+        liveness:
+          type: tcp
+          port: postgresql
+          timeout_seconds: 1
       service:
         type: ClusterIP
       ports:

--- a/inventory/classes/components/pritunl/pritunl-mongo.yml
+++ b/inventory/classes/components/pritunl/pritunl-mongo.yml
@@ -26,13 +26,20 @@ parameters:
         MONGODB_PASSWORD: ${pritunl:auth:password}
         MONGODB_DATABASE: ${pritunl:database:name}
       healthcheck:
-        type: command
-        command:
-          - mongo
-          - --eval
-          - "db.adminCommand('ping')"
-        probes: ['readiness', 'liveness']
-        timeout_seconds: 5
+        readiness:
+          type: command
+          command:
+            - mongo
+            - --eval
+            - "db.adminCommand('ping')"
+          timeout_seconds: 5
+        liveness:
+          type: command
+          command:
+            - mongo
+            - --eval
+            - "db.adminCommand('ping')"
+          timeout_seconds: 5
       volume_mounts:
         datadir:
           mountPath: /bitnami/mongodb
@@ -42,10 +49,10 @@ parameters:
             accessModes: ["ReadWriteOnce"]
             storageClassName: "standard"
             resources:
-              requests: 
+              requests:
                 storage: 10Gi
       secrets:
         secrets:
           data:
-            mongodb-root-password: 
+            mongodb-root-password:
               value: ?{plain:targets/${target_name}/mongodb_password||randomstr|base64}

--- a/inventory/classes/components/pritunl/pritunl.yml
+++ b/inventory/classes/components/pritunl/pritunl.yml
@@ -1,7 +1,7 @@
 parameters:
 
   pritunl:
-    database: 
+    database:
       name: pritunl
       connection_string: mongodb://${pritunl:auth:username}:${pritunl:auth:password}@pritunl-mongo:27017/${pritunl:database:name}
     auth:
@@ -20,12 +20,18 @@ parameters:
         webui:
           service_port: 443
       healthcheck:
-        type: http
-        scheme: HTTPS
-        path: /
-        port: webui
-        probes: ['readiness', 'liveness']
-        timeout_seconds: 3
+        readiness:
+          type: http
+          scheme: HTTPS
+          port: webui
+          path: /
+          timeout_seconds: 3
+        liveness:
+          type: http
+          scheme: HTTPS
+          port: webui
+          path: /
+          timeout_seconds: 3
       service:
         type: LoadBalancer
       security_context:
@@ -35,7 +41,7 @@ parameters:
           mount: /etc/pritunl.conf
           subPath: pritunl.conf
           data:
-            pritunl.conf: 
+            pritunl.conf:
               value: |-
                 {
                   "debug": false,

--- a/inventory/classes/components/queue-master.yml
+++ b/inventory/classes/components/queue-master.yml
@@ -8,11 +8,16 @@ parameters:
         http:
           service_port: 80
       healthcheck:
-        type: http
-        port: http
-        probes: ['readiness', 'liveness']
-        path: /health
-        timeout_seconds: 3
+        readiness:
+          type: http
+          port: http
+          path: /health
+          timeout_seconds: 3
+        liveness:
+          type: http
+          port: http
+          path: /health
+          timeout_seconds: 5
       env:
         ZIPKIN: zipkin.jaeger.svc.cluster.local
         JAVA_OPTS: "-Xms64m -Xmx128m -XX:PermSize=32m -XX:MaxPermSize=64m -XX:+UseG1GC -Djava.security.egd=file:/dev/urandom"

--- a/inventory/classes/components/weaveworks/carts.yml
+++ b/inventory/classes/components/weaveworks/carts.yml
@@ -17,12 +17,18 @@ parameters:
           add:
             - NET_BIND_SERVICE
       healthcheck:
-        type: http
-        port: http
-        probes: ['readiness', 'liveness']
-        path: /health
-        initial_delay_seconds: 120
-        timeout_seconds: 3
+        readiness:
+          type: http
+          port: http
+          path: /health
+          initial_delay_seconds: 120
+          timeout_seconds: 3
+        liveness:
+          type: http
+          port: http
+          path: /health
+          initial_delay_seconds: 120
+          timeout_seconds: 3
       env:
         ZIPKIN: zipkin.jaeger.svc.cluster.local
         JAVA_OPTS: "-Xms64m -Xmx128m -XX:PermSize=32m -XX:MaxPermSize=64m -XX:+UseG1GC -Djava.security.egd=file:/dev/urandom"

--- a/inventory/classes/components/weaveworks/catalogue.yml
+++ b/inventory/classes/components/weaveworks/catalogue.yml
@@ -19,8 +19,13 @@ parameters:
           add:
             - NET_BIND_SERVICE
       healthcheck:
-        type: http
-        port: http
-        probes: ['readiness', 'liveness']
-        path: /health
-        timeout_seconds: 3
+        readiness:
+          type: http
+          port: http
+          path: /health
+          timeout_seconds: 3
+        liveness:
+          type: http
+          port: http
+          path: /health
+          timeout_seconds: 5

--- a/inventory/classes/components/weaveworks/front-end.yml
+++ b/inventory/classes/components/weaveworks/front-end.yml
@@ -16,10 +16,15 @@ parameters:
           drop:
             - all
       healthcheck:
-        type: http
-        port: http
-        probes: ['readiness', 'liveness']
-        path: /
-        timeout_seconds: 3
+        readiness:
+          type: http
+          port: http
+          path: /
+          timeout_seconds: 3
+        liveness:
+          type: http
+          port: http
+          path: /
+          timeout_seconds: 5
       env:
         SESSION_REDIS: 'true'

--- a/inventory/classes/components/weaveworks/orders.yml
+++ b/inventory/classes/components/weaveworks/orders.yml
@@ -9,12 +9,17 @@ parameters:
         http:
           service_port: 80
       healthcheck:
-        type: http
-        port: http
-        probes: ['readiness', 'liveness']
-        path: /health
-        timeout_seconds: 3
-        initial_delay_seconds: 120
+        readiness:
+          type: http
+          port: http
+          path: /health
+          timeout_seconds: 3
+          initial_delay_seconds: 120
+        liveness:
+          type: http
+          port: http
+          path: /health
+          timeout_seconds: 5
       security_context:
         runAsNonRoot: true
         runAsUser: 10001

--- a/inventory/classes/components/weaveworks/payment.yml
+++ b/inventory/classes/components/weaveworks/payment.yml
@@ -17,8 +17,13 @@ parameters:
           add:
             - NET_BIND_SERVICE
       healthcheck:
-        type: http
-        port: http
-        probes: ['readiness', 'liveness']
-        path: /health
-        timeout_seconds: 3
+        readiness:
+          type: http
+          port: http
+          path: /health
+          timeout_seconds: 3
+        liveness:
+          type: http
+          port: http
+          path: /health
+          timeout_seconds: 5

--- a/inventory/classes/components/weaveworks/queue-master.yml
+++ b/inventory/classes/components/weaveworks/queue-master.yml
@@ -9,11 +9,16 @@ parameters:
         http:
           service_port: 80
       healthcheck:
-        type: http
-        port: http
-        probes: ['readiness', 'liveness']
-        path: /health
-        timeout_seconds: 3
+        readiness:
+          type: http
+          port: http
+          path: /health
+          timeout_seconds: 3
+        liveness:
+          type: http
+          port: http
+          path: /health
+          timeout_seconds: 5
       env:
         ZIPKIN: zipkin.jaeger.svc.cluster.local
         JAVA_OPTS: "-Xms64m -Xmx128m -XX:PermSize=32m -XX:MaxPermSize=64m -XX:+UseG1GC -Djava.security.egd=file:/dev/urandom"

--- a/inventory/classes/components/weaveworks/shipping.yml
+++ b/inventory/classes/components/weaveworks/shipping.yml
@@ -16,12 +16,17 @@ parameters:
           add:
             - NET_BIND_SERVICE
       healthcheck:
-        type: http
-        port: http
-        probes: ['readiness', 'liveness']
-        path: /health
-        timeout_seconds: 3
-        initial_delay_seconds: 120
+        readiness:
+          type: http
+          port: http
+          path: /health
+          timeout_seconds: 3
+          initial_delay_seconds: 120
+        liveness:
+          type: http
+          port: http
+          path: /health
+          timeout_seconds: 5
       env:
         ZIPKIN: zipkin.jaeger.svc.cluster.local
         JAVA_OPTS: "-Xms64m -Xmx128m -XX:PermSize=32m -XX:MaxPermSize=64m -XX:+UseG1GC -Djava.security.egd=file:/dev/urandom"

--- a/inventory/classes/components/weaveworks/user.yml
+++ b/inventory/classes/components/weaveworks/user.yml
@@ -18,11 +18,16 @@ parameters:
         runAsNonRoot: true
         runAsUser: 10001
       healthcheck:
-        type: http
-        port: http
-        probes: ['readiness', 'liveness']
-        path: /health
-        timeout_seconds: 3
+        readiness:
+          type: http
+          port: http
+          path: /health
+          timeout_seconds: 3
+        liveness:
+          type: http
+          port: http
+          path: /health
+          timeout_seconds: 5
       volume_mounts:
         tmp-volume:
           mountPath: /tmp

--- a/lib/kap.libsonnet
+++ b/lib/kap.libsonnet
@@ -189,7 +189,7 @@ kapitan + kube + {
     WithServiceAccountName(sa, service_name):: self + if utils.objectGet(sa, 'enabled', false) then { spec+: { template+: { spec+: { serviceAccountName: utils.objectGet(sa, 'name', service_name) } } } } else {},
     WithVolume(volume, enabled=true):: self + if enabled then { spec+: { template+: { spec+: { volumes_+: volume } } } } else {},
   },
-  
+
   K8sServiceAccount(name): $.K8sCommon(name) + kube.ServiceAccount(name) + {
     WithImagePullSecrets(secrets, enabled=true):: self + if enabled then { imagePullSecrets+: [secrets] } else {},
   },
@@ -204,8 +204,8 @@ kapitan + kube + {
   },
 
   K8sContainer(name, service_component, secrets_configs): kube.Container(name) {
-    WithLivenessProbe(healthchecks, spec):: self + if utils.arrayHas(healthchecks.probes, 'liveness') then { livenessProbe: HealthCheck(spec) } else {},
-    WithReadinessProbe(healthchecks, spec):: self + if utils.arrayHas(healthchecks.probes, 'readiness') then { readinessProbe: HealthCheck(spec) } else {},
+    WithLivenessProbe(healthchecks, spec):: self + if utils.objectHas(healthchecks, 'liveness') then { livenessProbe: HealthCheck(spec.liveness) } else {},
+    WithReadinessProbe(healthchecks, spec):: self + if utils.objectHas(healthchecks, 'readiness') then { readinessProbe: HealthCheck(spec.readiness) } else {},
     WithCommand(command):: self + { command: command },
     WithArgs(args):: self + { args: args },
     WithImage(image):: self + { image_:: image },


### PR DESCRIPTION
#34 

Change yaml schema so instead of providing a single healthcheck configuration and applying it to each of the probe types ('liveness' and 'readiness') in a 'probes' array, we provide separate configurations for each probe type separately.

Main changes are in kap.libjsonnet, schemas.libjsonnet and resources.libjsonnet. Have updated all required example inventory files so the manifests still compile. I also updated schema.json as it didn't appear to be valid json before (`jsonnet schemas.libsonnet | jq ".service_component" > schema.json` ) 