### PR TITLE
change the reference branch for the kadet generator

### DIFF
--- a/inventory/classes/kapitan/generators/kubernetes.yml
+++ b/inventory/classes/kapitan/generators/kubernetes.yml
@@ -3,7 +3,7 @@ parameters:
     dependencies:
     - type: git
       source: https://github.com/kapicorp/kapitan-reference.git
-      ref: kadet
+      ref: master
       subdir: components/generators/kubernetes
       output_path: components/generators/kubernetes
     compile:


### PR DESCRIPTION
Fix reported issue caused by the `kadet` branch not existing anymore

