### PR TITLE
Upgrade ingress and improve network policies

### DIFF
--- a/compiled/echo-server/manifests/echo-server-bundle.yml
+++ b/compiled/echo-server/manifests/echo-server-bundle.yml
@@ -124,6 +124,7 @@ spec:
         - port: 6379
           protocol: TCP
   podSelector:
-    label: test
+    matchLabels:
+      name: echo-server
   policyTypes:
     - Ingress

--- a/compiled/echo-server/manifests/global-ingress.yml
+++ b/compiled/echo-server/manifests/global-ingress.yml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   labels:
@@ -10,6 +10,9 @@ spec:
     - http:
         paths:
           - backend:
-              serviceName: echo-server
-              servicePort: 80
+              service:
+                name: echo-server
+                port:
+                  number: 80
             path: /echo/*
+            pathType: Prefix

--- a/compiled/prod-sockshop/manifests/global-ingress.yml
+++ b/compiled/prod-sockshop/manifests/global-ingress.yml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
@@ -10,5 +10,7 @@ metadata:
   namespace: prod-sockshop
 spec:
   backend:
-    serviceName: frontend
-    servicePort: 80
+    service:
+      name: frontend
+      port:
+        number: 80

--- a/compiled/tutorial/manifests/echo-server-bundle.yml
+++ b/compiled/tutorial/manifests/echo-server-bundle.yml
@@ -127,6 +127,7 @@ spec:
         - port: 6379
           protocol: TCP
   podSelector:
-    label: test
+    matchLabels:
+      name: echo-server
   policyTypes:
     - Ingress

--- a/compiled/tutorial/manifests/global-ingress.yml
+++ b/compiled/tutorial/manifests/global-ingress.yml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   labels:
@@ -10,6 +10,9 @@ spec:
     - http:
         paths:
           - backend:
-              serviceName: echo-server
-              servicePort: 80
+              service:
+                name: echo-server
+                port:
+                  number: 80
             path: /echo/*
+            pathType: Prefix

--- a/inventory/classes/components/echo-server.yml
+++ b/inventory/classes/components/echo-server.yml
@@ -29,8 +29,6 @@ parameters:
       # One or many network policies
       network_policies:
         default:
-          pod_selector: 
-            label: test
           ingress:
             - from:
               - podSelector:
@@ -108,6 +106,9 @@ parameters:
     global:
       paths:
         - backend:
-            serviceName: echo-server
-            servicePort: 80
+            service:
+              name: echo-server
+              port:
+                number: 80
           path: /echo/*
+          pathType: Prefix

--- a/inventory/targets/kapicorp/prod-sockshop.yml
+++ b/inventory/targets/kapicorp/prod-sockshop.yml
@@ -17,5 +17,7 @@ parameters:
       domains:
       - sockshop.kapicorp.com
       default_backend:
-        serviceName: frontend
-        servicePort: 80
+        service:
+          name: frontend
+          port:
+            number: 80

--- a/lib/kube.libsonnet
+++ b/lib/kube.libsonnet
@@ -565,7 +565,7 @@
     },
   },
 
-  Ingress(name): $._Object('networking.k8s.io/v1beta1', 'Ingress', name) {
+  Ingress(name): $._Object('networking.k8s.io/v1', 'Ingress', name) {
     spec: {},
 
     local rel_paths = [


### PR DESCRIPTION
* upgrade ingress to v1
* upgrade network policies to take selector from workload

@alanhughes FYI

fixes 
```
Warning: extensions/v1beta1 Ingress is deprecated in v1.14+, unavailable in v1.22+; use networking.k8s.io/v1 Ingress
```