### PR TITLE
#70: versioned secrets/configs refactoring

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "python.pythonPath": "/usr/local/opt/python@3.9/bin/python3.9"
+}

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Compiled sock-shop (4.36s)
 
 ## Slow walk-through
 
-[Manifest Generator Documentation](components/generators/manifests/README.md)
+[Manifest Generator Documentation](components/generators/kubernetes/README.md)
 
 ### Tools
 
@@ -125,7 +125,7 @@ To help you get started, please look at the following examples:
 | ------ | ----------- | ------ |
 |[echo-server](inventory/classes/components/echo-server.yml)| Defining ingress paths using [echo-server](https://github.com/jmalloc/echo-server) | [manifests](compiled/echo-server/manifests)|
 
-[Documentation](components/generators/ingresses/README.md)
+[Documentation](components/generators/kubernetes/README.md)
 
 ### Request or submit your examples
 We have used this generator extensively, and we know it covers the majority of the use cases.

--- a/compiled/echo-server/manifests/echo-server-bundle.yml
+++ b/compiled/echo-server/manifests/echo-server-bundle.yml
@@ -83,7 +83,7 @@ spec:
       volumes:
         - configMap:
             defaultMode: 420
-            name: echo-server
+            name: echo-server-01f3716a
           name: config
         - name: secret
           secret:

--- a/compiled/echo-server/manifests/echo-server-config.yml
+++ b/compiled/echo-server/manifests/echo-server-config.yml
@@ -12,5 +12,5 @@ kind: ConfigMap
 metadata:
   labels:
     name: echo-server
-  name: echo-server
+  name: echo-server-01f3716a
   namespace: echo-server

--- a/compiled/examples/manifests/mysql-bundle.yml
+++ b/compiled/examples/manifests/mysql-bundle.yml
@@ -57,7 +57,7 @@ spec:
         - name: secrets
           secret:
             defaultMode: 420
-            secretName: mysql
+            secretName: mysql-28b5dcb9
   updateStrategy:
     rollingUpdate:
       partition: 0

--- a/compiled/examples/manifests/mysql-secret.yml
+++ b/compiled/examples/manifests/mysql-secret.yml
@@ -6,6 +6,6 @@ kind: Secret
 metadata:
   labels:
     name: mysql
-  name: mysql
+  name: mysql-28b5dcb9
   namespace: examples
 type: Opaque

--- a/compiled/mysql/manifests/mysql-bundle.yml
+++ b/compiled/mysql/manifests/mysql-bundle.yml
@@ -57,7 +57,7 @@ spec:
         - name: secrets
           secret:
             defaultMode: 420
-            secretName: mysql
+            secretName: mysql-859eb789
   updateStrategy:
     rollingUpdate:
       partition: 0

--- a/compiled/mysql/manifests/mysql-secret.yml
+++ b/compiled/mysql/manifests/mysql-secret.yml
@@ -6,6 +6,6 @@ kind: Secret
 metadata:
   labels:
     name: mysql
-  name: mysql
+  name: mysql-859eb789
   namespace: mysql
 type: Opaque

--- a/compiled/tutorial/manifests/echo-server-bundle.yml
+++ b/compiled/tutorial/manifests/echo-server-bundle.yml
@@ -86,7 +86,7 @@ spec:
       volumes:
         - configMap:
             defaultMode: 420
-            name: echo-server
+            name: echo-server-79541426
           name: config
         - name: secret
           secret:

--- a/compiled/tutorial/manifests/echo-server-config.yml
+++ b/compiled/tutorial/manifests/echo-server-config.yml
@@ -12,5 +12,5 @@ kind: ConfigMap
 metadata:
   labels:
     name: echo-server
-  name: echo-server
+  name: echo-server-79541426
   namespace: tutorial

--- a/components/generators/kubernetes/README.md
+++ b/components/generators/kubernetes/README.md
@@ -405,6 +405,38 @@ In summary, remember that you can summon the power of Google KMS (once setup) an
 
 which will generate an truly encrypted secret using Google KMS (other backends also available)
 
+### Versioned ConfigMaps and Secrets
+
+The generator can automatically "version" you ConfigMap or Secrets so that the associated workload can automatically detect the change and handle it appropriately (rollout restart)
+
+In both secrets and config_maps, just define `version: true` (default: `false`)
+
+```yaml
+      config_maps:
+        config:
+          version: true
+          mount: /opt/echo-service
+          data:
+            example.txt:
+              file: 'components/echo-server/example.txt'
+```
+
+The generator will hash the content of the resource, and add it to the name of the rendered object:
+
+```
+kind: ConfigMap
+metadata:
+  labels:
+    name: echo-server
+  name: echo-server-01f3716a
+  namespace: echo-server
+  [cut]
+```
+
+when the content of the object changes, the hash will be updated accordingly.
+
+**PLEASE NOTE:** `kapitan` is not responsible for garbage collecting unused secrets of config maps.
+
 ## StatefulSet
 
 You can define a *StatefulSet* by using the `type` directive to `statefulset` (that normally defaults to `deployment`)

--- a/components/generators/kubernetes/k8s.py
+++ b/components/generators/kubernetes/k8s.py
@@ -9,8 +9,9 @@ class Base(BaseObj):
     def body(self):
         self.root.apiVersion = self.kwargs.apiVersion
         self.root.kind = self.kwargs.kind
-        self.root.metadata.name = self.kwargs.name
-        self.add_label('name', self.kwargs.name)
+        self.name = self.kwargs.name
+        self.root.metadata.name = self.kwargs.get("rendered_name", self.name)
+        self.add_label('name', self.root.metadata.name)
 
     def add_labels(self, labels):
         for key, value in labels.items():

--- a/inventory/classes/components/echo-server.yml
+++ b/inventory/classes/components/echo-server.yml
@@ -80,6 +80,7 @@ parameters:
         config:
           mount: /opt/echo-service/echo-service.conf
           subPath: echo-service.conf
+          version: true
           data:
             echo-service.conf:
               template: "components/echo-server/echo-server.conf.j2"

--- a/inventory/classes/components/mysql.yml
+++ b/inventory/classes/components/mysql.yml
@@ -51,6 +51,7 @@ parameters:
 
       secrets:
         secrets:
+          version: true
           data:
             mysql-root-password: 
               value: ?{plain:targets/${target_name}/mysql-root-password||randomstr:32|base64}


### PR DESCRIPTION
### Versioned ConfigMaps and Secrets

The generator can automatically "version" you ConfigMap or Secrets so that the associated workload can automatically detect the change and handle it appropriately (rollout restart)

In both secrets and config_maps, just define `version: true` (default: `false`)

```yaml
      config_maps:
        config:
          version: true
          mount: /opt/echo-service
          data:
            example.txt:
              file: 'components/echo-server/example.txt'
```

The generator will hash the content of the resource, and add it to the name of the rendered object:

```
kind: ConfigMap
metadata:
  labels:
    name: echo-server
  name: echo-server-01f3716a
  namespace: echo-server
  [cut]
```

when the content of the object changes, the hash will be updated accordingly.

**PLEASE NOTE:** `kapitan` is not responsible for garbage collecting unused secrets of config maps.

FYI @Moep90  this is one way to solve #73 