### PR TITLE
add init_containers support

### DIFF
--- a/compiled/echo-server/manifests/echo-server-bundle.yml
+++ b/compiled/echo-server/manifests/echo-server-bundle.yml
@@ -81,6 +81,12 @@ spec:
             - mountPath: /etc/nginx/conf.d/nginx.conf
               name: config
               subPath: nginx.conf
+      initContainers:
+        - command:
+            - echo "test"
+          image: docker pull busybox
+          imagePullPolicy: IfNotPresent
+          name: busybox
       restartPolicy: Always
       terminationGracePeriodSeconds: 30
       volumes:

--- a/compiled/tutorial/manifests/echo-server-bundle.yml
+++ b/compiled/tutorial/manifests/echo-server-bundle.yml
@@ -83,6 +83,12 @@ spec:
             - mountPath: /etc/nginx/conf.d/nginx.conf
               name: config
               subPath: nginx.conf
+      initContainers:
+        - command:
+            - echo "test"
+          image: docker pull busybox
+          imagePullPolicy: IfNotPresent
+          name: busybox
       restartPolicy: Always
       terminationGracePeriodSeconds: 30
       volumes:

--- a/components/generators/kubernetes/README.md
+++ b/components/generators/kubernetes/README.md
@@ -598,6 +598,25 @@ parameters:
                 }
 ```
 
+## Init Containers
+
+You can instruct the generator to create initContainers by using the `init_containers` directive:
+
+```yaml
+parameters:
+  components:
+    echo-server:
+      <other config>
+      # Init containers
+      init_containers:
+        busybox:
+          image: busybox
+          commands:
+          - echo test
+```
+
+Just like the `additional_containers`, tou can access the same config_maps and secrets as the main container, but you can override mountpoints and subPaths.
+
 ## Network Policies
 
 You can also generate Network Policies by simply adding them under the `network_policies` structure.

--- a/components/generators/kubernetes/__init__.py
+++ b/components/generators/kubernetes/__init__.py
@@ -41,6 +41,10 @@ class WorkloadCommon(BaseObj):
         self.root.spec.template.spec.containers += [
             container.root for container in containers]
 
+    def add_init_containers(self, containers):
+        self.root.spec.template.spec.initContainers += [
+            container.root for container in containers]
+
     def add_volumes(self, volumes):
         for key, value in volumes.items():
             merge({"name": key}, value)
@@ -521,6 +525,11 @@ class Workload(WorkloadCommon):
                                  component.additional_containers.items()]
         workload.add_containers([container])
         workload.add_containers(additional_containers)
+
+        init_containers = [Container(name=name, container=component) for name, component in
+                            component.init_containers.items()]
+
+        workload.add_init_containers(init_containers)
         workload.root.spec.template.spec.imagePullSecrets = component.image_pull_secrets
         workload.root.spec.template.spec.dnsPolicy = component.dns_policy
         workload.root.spec.template.spec.terminationGracePeriodSeconds = component.get(

--- a/inventory/classes/components/echo-server.yml
+++ b/inventory/classes/components/echo-server.yml
@@ -10,6 +10,12 @@ parameters:
       image: jmalloc/echo-server
       pull_policy: Always
 
+      init_containers:
+        busybox:
+          image: docker pull busybox
+          command:
+            - echo "test"
+
       env:
         NODENAME:
           fieldRef:


### PR DESCRIPTION
Add support for init containers, under the `init_containers` key.

```
      init_containers:
        busybox:
          image: docker pull busybox
          command:
            - echo "test"
```

Implements #77  @Moep90 