### PR TITLE
terrraform generator references missing ref of ademariag/kapitan-reference

### DIFF
--- a/inventory/classes/kapitan/generators/terraform.yml
+++ b/inventory/classes/kapitan/generators/terraform.yml
@@ -2,8 +2,8 @@ parameters:
   kapitan:
     dependencies:
     - type: git
-      source: https://github.com/ademariag/kapitan-reference.git
-      ref: terraform-generator
+      source: https://github.com/kapicorp/kapitan-reference.git
+      ref: master
       subdir: components/generators/terraform
       output_path: components/generators/terraform
     compile:


### PR DESCRIPTION
The terraform generator currently references a non-existent ref of ademariag/kapitan-reference rather than master on kapicorp/kapitan-reference